### PR TITLE
Update concurrency limits section in billing-limits.mdx

### DIFF
--- a/fern/billing/billing-limits.mdx
+++ b/fern/billing/billing-limits.mdx
@@ -13,7 +13,7 @@ You can set billing limits in the billing section of your dashboard.
 </Note>
 
 ### Concurrency Limits
-Vapi has concurrency limits on inbound and outbound calls. These limits has maximum number of simultaneous calls your account can handle concurrently. Exceeding your concurrency limit causes new requests to queue or be rejected until existing calls finish.
+Vapi has concurrency limits on both inbound and outbound calls. These limits define the maximum number of simultaneous calls your account can handle. Exceeding your concurrency limit causes new requests to queue or be rejected until existing calls finish.
 
 - The default concurrency limit is 10 simultaneous calls(inbound and outbound calls combined). This limit applies to your entire account and is not dependent on the number of users or organizations associated with it.
 


### PR DESCRIPTION
Reason for the PR:
This update to the documentation is made in response to a need for clearer information regarding concurrency limits in Vapi, particularly in the context of the Billing section. Users were encountering confusion about the limits for simultaneous calls and the costs mentioned via the dashboard. The default limit and the process to increase concurrency were not clearly outlined.

Additionally, there was an inquiry in the Discord community from a [user](https://discord.com/channels/1211482211119796234/1228667357849849856/1314524397050138704) regarding the concurrency limits for high volume, which highlighted the need to ensure this information is easily accessible to all users.